### PR TITLE
Change provider_id field to varchar(25)

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `user_provider` (
   `user_id` int(11) NOT NULL,
-  `provider_id` int(11) NOT NULL,
+  `provider_id` varchar(25) NOT NULL,
   `provider` varchar(255) NOT NULL,
   PRIMARY KEY (`user_id`),
   UNIQUE KEY (`provider_id`,`provider`),


### PR DESCRIPTION
Google's ID's are very long integers such as:

113574631361210648490

This is too large for an int, unsigned int, or even an unsigned bigint
field. Due to this, varchar seems like the next logical choice.
