### PR TITLE
Fix issue with "readonly" table

### DIFF
--- a/src/ScnSocialAuth/Mapper/UserProvider.php
+++ b/src/ScnSocialAuth/Mapper/UserProvider.php
@@ -11,15 +11,13 @@ class UserProvider extends AbstractDbMapper implements UserProviderInterface
 
     public function findUserByProviderId($providerId, $provider)
     {
-        $select = $this
-            ->getSelect()
-            ->from($this->tableName)
-            ->where(
-                array(
-                    'provider_id' => $providerId,
-                    'provider' => $provider,
-                )
-            );
+        $sql    = $this->getSql();
+        $select = $sql->select();
+        $select->from($this->tableName)
+               ->where(array(
+                   'provider_id' => $providerId,
+                   'provider'    => $provider,
+               ));
 
         $entity = $this->select($select)->current();
         $this->getEventManager()->trigger('find', $this, array('entity' => $entity));


### PR DESCRIPTION
- Using getSelect() was leading to an issue against current ZF2 master whereby
  the table was being marked as readonly; this meant that later calling from()
  led to an exception. This patch fixes that issue by pulling the select() from
  a Sql object and then calling setTable().
