### PR TITLE
ZfcUser state

### DIFF
--- a/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
+++ b/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
@@ -418,6 +418,15 @@ class HybridAuth extends AbstractAdapter implements ServiceManagerAwareInterface
      */
     protected function insert($user, $provider, $userProfile)
     {
+        $zfcUserOptions = $this->getZfcUserOptions();
+
+        // If user state is enabled, set the default state value
+        if ($zfcUserOptions->getEnableUserState()) {
+            if ($zfcUserOptions->getDefaultUserState()) {
+                $user->setState($zfcUserOptions->getDefaultUserState());
+            }
+        }
+
         $options = array(
             'user'          => $user,
             'provider'      => $provider,


### PR DESCRIPTION
I think that ZfcUser's state should be set before calling insert on the mapper, otherwise the user's state won't get set when registering with a social network.
