### PR TITLE
Add support for Google Apps domain restriction.

### DIFF
--- a/config/scn-social-auth.local.php.dist
+++ b/config/scn-social-auth.local.php.dist
@@ -63,6 +63,13 @@ $settings = array(
     //'google_secret' => 'your-secret',
 
     /**
+     * Google Hosted Domain
+     *
+     * OPTIONAL: Limit Google logins to a specific hosted domain (Google Apps)
+     */
+    //'google_hd' => 'your-domain.tld',
+
+    /**
      * LinkedIn Client ID
      *
      * Please specify a LinkedIn Client ID

--- a/src/ScnSocialAuth/Options/ModuleOptions.php
+++ b/src/ScnSocialAuth/Options/ModuleOptions.php
@@ -107,6 +107,11 @@ class ModuleOptions extends AbstractOptions
     protected $googleScope;
 
     /**
+     * @var string
+     */
+    protected $googleHd;
+
+    /**
      * @var boolean
      */
     protected $linkedInEnabled = false;
@@ -563,6 +568,29 @@ class ModuleOptions extends AbstractOptions
     public function getGoogleScope()
     {
         return $this->googleScope;
+    }
+
+    /**
+     * set google Hd
+     *
+     * @param  string        $googleHd
+     * @return ModuleOptions
+     */
+    public function setGoogleHd($googleHd)
+    {
+        $this->googleHd = (string) $googleHd;
+
+        return $this;
+    }
+
+    /**
+     * get google Hd
+     *
+     * @return string
+     */
+    public function getGoogleHd()
+    {
+        return $this->googleHd;
     }
 
     /**

--- a/src/ScnSocialAuth/Service/HybridAuthFactory.php
+++ b/src/ScnSocialAuth/Service/HybridAuthFactory.php
@@ -68,6 +68,7 @@ class HybridAuthFactory implements FactoryInterface
                             'secret' => $options->getGoogleSecret(),
                         ),
                         'scope' => $options->getGoogleScope(),
+                        'hd' => $options->getGoogleHd(),
                     ),
                     'LinkedIn' => array(
                         'enabled' => $options->getLinkedInEnabled(),


### PR DESCRIPTION
Google supports passing a "hd" parameter to only allow user's from that specific Hosted Domain (Google Apps) to login.

Use case:
Creating internal applications that utilise existing Google Apps infrastructure for a Single Sign On approach.
