### PR TITLE
Fundamental bug - social signin not working!

### DIFF
--- a/src/ScnSocialAuth/Controller/UserController.php
+++ b/src/ScnSocialAuth/Controller/UserController.php
@@ -88,7 +88,7 @@ class UserController extends AbstractActionController
         if ($this->getServiceLocator()->get('zfcuser_module_options')->getUseRedirectParameterIfPresent() && $this->getRequest()->getQuery()->get('redirect')) {
             $query = array_merge($query, array('redirect' => $this->getRequest()->getQuery()->get('redirect')));
         }
-        $redirectUrl = $this->url()->fromRoute('scn-social-auth-user/authenticate', array('query' => $query));
+        $redirectUrl = $this->url()->fromRoute('scn-social-auth-user/authenticate', array(), array('query' => $query));
 
         $adapter = $hybridAuth->authenticate(
             $provider,


### PR DESCRIPTION
The 'provider' query parameter not getting set in the 'scn-social-auth-user/authenticate' url.

After upgrading to 1.9.3 'social sign in' ceased working.

The 'provider' query parameter was not getting set correctly in the post callback redirectUrl, so it would seem that ScnSocialAuth\Authentication\Adapter\HybridAuth::authenticate was failing silently with its absence.

Prior to 1.9.3 the presence of a query subroute ensured that the query params were set correctly as part of $params parameters in Zend\Mvc\Controller\Plugin\Url::fromRoute, however with the removal of the subroute, the query parameters must be set using the $options parameter of fromRoute.
