### PR TITLE
utf8_decode Display name for Twitter

### DIFF
--- a/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
+++ b/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
@@ -404,7 +404,7 @@ class HybridAuth extends AbstractAdapter implements ServiceManagerAwareInterface
     {
         $localUser = $this->instantiateLocalUser();
         $localUser->setUsername($userProfile->displayName)
-            ->setDisplayName($userProfile->firstName)
+            ->setDisplayName(utf8_decode($userProfile->firstName))
             ->setPassword(__FUNCTION__);
         $result = $this->insert($localUser, 'twitter', $userProfile);
 


### PR DESCRIPTION
When user sign in with Twitter, the display name (in database) could contain bad characters due to the encoding.
