### PR TITLE
Trigger register.post event after inserting new user-to-provider

### DIFF
--- a/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
+++ b/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
@@ -122,7 +122,7 @@ class HybridAuth extends AbstractAdapter implements ServiceManagerAwareInterface
                 ->setProviderId($userProfile->identifier)
                 ->setProvider($provider);
             $this->getMapper()->insert($localUserProvider);
-            
+
             // Trigger register.post event
             $this->getEventManager()->trigger('register.post', $this, array('user' => $localUser, 'userProvider' => $localUserProvider));
         }


### PR DESCRIPTION
Based on this issue: https://github.com/SocalNick/ScnSocialAuth/issues/80

We will just trigger this event so we can catch it the same way like we do in ZfcUser register.post.

This event will provide you current user and current user-to-provider.
