### PR TITLE
Fix for issue #91.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ return array(
 
 Import the schemas for ZfcUser (`./vendor/zf-commons/zfc-user/data/schema.sql`) and ScnSocialAuth (`./vendor/socalnick/scn-social-auth/data/schema.sql`).
 
+Find in `./config/autoload/zfcuser.global.php`:
+```
+'auth_adapters' => array( 100 => 'ZfcUser\Authentication\Adapter\Db' )
+```
+and change it to :
+```
+'auth_adapters' => array( 90 => 'ScnSocialAuth\Authentication\Adapter\HybridAuth', 100 => 'ZfcUser\Authentication\Adapter\Db' )
+```
+
 If you do not already have a valid Zend\Db\Adapter\Adapter in your service
 manager configuration, put the following in `./config/autoload/database.local.php`:
 ```

--- a/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
+++ b/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
@@ -148,9 +148,9 @@ class HybridAuth extends AbstractAdapter implements ServiceManagerAwareInterface
         $storage = $this->getStorage()->read();
         $storage['identity'] = $authEvent->getIdentity();
         $this->getStorage()->write($storage);
+
         $authEvent->setCode(Result::SUCCESS)
-          ->setMessages(array('Authentication successful.'))
-          ->stopPropagation();
+                  ->setMessages(array('Authentication successful.'));
     }
 
     /**


### PR DESCRIPTION
This issue appeared because ScnSocialAuth did event stopPropogation, and this approach had worked before ZfcUser was not changed to rise exceptions when event was stopped.

Previous in `ZfcUser/Authentication/Adapter/AdapterChain.php` :

```
public function prepareForAuthentication(Request $request) {
...
if ($result->stopped()) {
            if($result->last() instanceof Response) {
                return $result->last();
            } else {
                // throw new Exception('Auth event was stopped without a response.');
            }
        }
```

Now in `ZfcUser/Authentication/Adapter/AdapterChain.php` :

```
public function prepareForAuthentication(Request $request) {
...
if ($result->stopped()) {
            if($result->last() instanceof Response) {
                return $result->last();
            }

            throw new Exception\AuthenticationEventException(
                sprintf(
                    'Auth event was stopped without a response. Got "%s" instead',
                    is_object($result->last()) ? get_class($result->last()) : gettype($result->last())
                )
            );
        }
```
