### PR TITLE
Fixed problem with setting Auth Adapter

### DIFF
--- a/src/ScnSocialAuth/Controller/UserController.php
+++ b/src/ScnSocialAuth/Controller/UserController.php
@@ -140,14 +140,14 @@ class UserController extends AbstractActionController
         // Clear existing listeners as we only want HybridAuth as authentication method
         $chain->getEventManager()->clearListeners('authenticate');
         $chain->getEventManager()->clearListeners('logout');
-        if(is_callable(array($adapter, 'authenticate'))) {
+        if (is_callable(array($adapter, 'authenticate'))) {
                 $chain->getEventManager()->attach('authenticate', array($adapter, 'authenticate'), 100);
             }
-        
-        if(is_callable(array($adapter, 'logout'))) {
+
+        if (is_callable(array($adapter, 'logout'))) {
                 $chain->getEventManager()->attach('logout', array($adapter, 'logout'), 100);
             }
-        
+
         // Update zfcuser_auth_service to use the HybridAuth adapter also
         $zfcUserAuthService = $this->getServiceLocator()->get('zfcuser_auth_service');
         $zfcUserAuthService->setAdapter($this->getServiceLocator()->get('ZfcUser\Authentication\Adapter\AdapterChain'));


### PR DESCRIPTION
Currently if any other module calls the AdapterChainFactory prior to ScnSocialAuth (for example BjyAuthorize) then the Auth Adapter defaults back to ZendDB. 

See :

https://github.com/bjyoungblood/BjyAuthorize/issues/208

and

https://github.com/SocalNick/ScnSocialAuth/issues/123

To fix the issue I remove any previously attached listeners for authenticate and logout and replace with HybridAuth adapter instances for those events.

As a precaution I also reset the adapter on the zfcuser_auth_service.

The outcome is the same as the previous technique of settings the Module Options on the fly (in that we enforce te HydridAuth adapter exclusively). This will overwrite any previously configured adapters.

I have tested with BjyAuthorize.
