### PR TITLE
Update ZfcUser dependency to 1.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
         "zf-commons/zfc-base": "0.1.*",
-        "zf-commons/zfc-user": "1.0.*",
+        "zf-commons/zfc-user": "1.1.*",
         "hybridauth/hybridauth": "2.2.*"
     },
     "require-dev": {


### PR DESCRIPTION
There is a security release of ZfcUser: https://github.com/ZF-Commons/ZfcUser/releases

Or maybe we should use `~1.1` so we don't have to keep changing `composer.json` file every time `ZfcUser` has a minor update. 

Let me know your thoughts :)
