### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
         "zf-commons/zfc-base": "0.1.*",
-        "zf-commons/zfc-user": ">=1.2.2 <2.0.0",
-        "hybridauth/hybridauth": "2.2.*"
+        "zf-commons/zfc-user": "~1.2",
+        "hybridauth/hybridauth": "~2.2"
     },
     "require-dev": {
         "mockery/mockery": "0.8.0"


### PR DESCRIPTION
Current version record dependence zfc-user incompatible with last composer API and give Exception:
```bash
PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'Could not parse version constraint >=1.2.2 <2.0.0: Invalid version string "1.2.2 <2.0.0"' in /var/www/frontend/shared/ven
dor/composer/composer/src/Composer/Package/Version/VersionParser.php:378
Stack trace:
#0 /var/www/frontend/shared/vendor/composer/composer/src/Composer/Package/Version/VersionParser.php(244): Composer\Package\Version\VersionParser->parseConstraint('>=1.2.2 <2.0.0')
#1 /var/www/frontend/shared/vendor/composer/composer/src/Composer/Package/Version/VersionParser.php(207): Composer\Package\Version\VersionParser->parseConstraints('>=1.2.2 <2.0.0')
#2 /var/www/frontend/shared/vendor/composer/composer/src/Composer/Package/Loader/ArrayLoader.php(123): Composer\Package\Version\VersionParser->parseLinks('socalnick/scn-s...', '1.16.0', 'requires', A
rray)
#3 /var/www/frontend/shared/vendor/composer/composer/src/Composer/Repository/FilesystemRepository.php(62): Composer\Package\Loader\ArrayLoader->load(Array)
#4 /var/www/frontend/shared/vendor/ in /var/www/frontend/shared/vendor/composer/composer/src/Composer/Package/Version/VersionParser.php on line 378
```

I propose use Tilde Operator ("~") https://getcomposer.org/doc/01-basic-usage.md#package-versions
This will be better then now.