### PR TITLE
Redirect when route scn-social-auth-user/register

### DIFF
--- a/src/ScnSocialAuth/Controller/RedirectCallback.php
+++ b/src/ScnSocialAuth/Controller/RedirectCallback.php
@@ -114,6 +114,7 @@ class RedirectCallback
         switch ($currentRoute) {
             case 'zfcuser/login':
             case 'scn-social-auth-user/login':
+            case 'scn-social-auth-user/register':
             case 'scn-social-auth-user/authenticate/provider':
             case 'scn-social-auth-user/add-provider/provider':
                 $route = ($redirect) ?: $this->options->getLoginRedirectRoute();


### PR DESCRIPTION
When performing non-social registration, now redirectioning to configured route.