### PR TITLE
fix shared state when a user is disabled

### DIFF
--- a/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
+++ b/src/ScnSocialAuth/Authentication/Adapter/HybridAuth.php
@@ -154,6 +154,7 @@ class HybridAuth extends AbstractAdapter implements ServiceManagerAwareInterface
             $mapper = $this->getZfcUserMapper();
             $user = $mapper->findById($localUserProvider->getUserId());
             if (!in_array($user->getState(), $zfcUserOptions->getAllowedLoginStates())) {
+                $this->hybridAuth->getAdapter($provider)->adapter->setUserUnconnected();
                 $authEvent->setCode(Result::FAILURE_UNCATEGORIZED)
                   ->setMessages(array('A record with the supplied identity is not active.'));
                 $this->setSatisfied(false);


### PR DESCRIPTION
When a user log in but is disabled, the adapter believes that the user is already logged in and triggers a redirect.
How to test:
- Register with facebook user
- Disable this user
- Log in with this user with facebook, we see an error message
- Log in again, before patch, the user is redirected to whatever the default login route is, after patch, we see the same error message as above

To test again, empty your cookies
